### PR TITLE
Added new EMC screenname to the display800 skins

### DIFF
--- a/skins/display800/OE-A_LCDSkin_1/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_1/skin_display.xml
@@ -606,7 +606,10 @@
 		</widget>
         <eLabel position="0,375" size="800,4" backgroundColor="#FF0000" />
 	</screen>
-	
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+
 	<!-- EMCSelectionExtended_summary 
 	<screen name="EMCSelectionExtended_summary" position="0,0" size="800,480" >
 	<panel name="EMCSelection_summary" />

--- a/skins/display800/OE-A_LCDSkin_10/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_10/skin_display.xml
@@ -477,6 +477,9 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
+ 	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >

--- a/skins/display800/OE-A_LCDSkin_11/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_11/skin_display.xml
@@ -453,7 +453,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >
   <widget name="text1" position="20,125" size="740,205" font="VFD;50" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_12/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_12/skin_display.xml
@@ -447,7 +447,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >
   <widget name="text1" position="20,125" size="740,205" font="VFD;50" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_13/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_13/skin_display.xml
@@ -298,7 +298,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >
   <widget name="text1" position="20,125" size="740,205" font="VFD;50" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_14/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_14/skin_display.xml
@@ -457,7 +457,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >
   <widget name="text1" position="20,125" size="740,205" font="VFD;50" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_15/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_15/skin_display.xml
@@ -462,6 +462,9 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >

--- a/skins/display800/OE-A_LCDSkin_16/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_16/skin_display.xml
@@ -138,7 +138,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >
   <widget name="text1" position="20,125" size="740,205" font="VFD;50" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_17/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_17/skin_display.xml
@@ -482,7 +482,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480">
   <widget name="text1" position="20,125" size="740,185" font="VFD;45" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_18/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_18/skin_display.xml
@@ -484,7 +484,10 @@
     <convert type="ClockToText">AsLength</convert>
   </widget>
  </screen>
-
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+ 
 <!-- MediaPlayer  -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480">
   <widget name="text1" position="20,125" size="740,185" font="VFD;45" halign="left" valign="center" transparent="1" />

--- a/skins/display800/OE-A_LCDSkin_8/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_8/skin_display.xml
@@ -145,7 +145,10 @@
          <convert type="ClockToText">InMinutes</convert>
       </widget>
    </screen>
-   
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
+
    <!-- MoviePlayer_SimplePlayerMP -->
    <screen name="InfoBarMoviePlayerSummary" position="0,0" size="800,480" >
       <widget source="global.CurrentTime" render="Label" position="430,40" size="350,120" font="VFDB;130" halign="right" valign="center">

--- a/skins/display800/OE-A_LCDSkin_9/skin_display.xml
+++ b/skins/display800/OE-A_LCDSkin_9/skin_display.xml
@@ -137,6 +137,9 @@
     <convert type="ServiceName">Name</convert>
   </widget>
  </screen>
+	<screen name="EMCSelectionOwn_summary" position="0,0" size="800,480">
+		<panel name="EMCSelection_summary" />
+	</screen>
  
 <!-- Media Player -->
 <screen name="MediaPlayerLCDScreen" position="0,0" size="800,480" >


### PR DESCRIPTION
EMC has recently changed the `EMCSelection_summary` screen to `EMCSelectionOwn_summary`

Simple fix to redirect to the previous name.